### PR TITLE
Implement custom WhitespacePathNormalizer to fix issue with paths containing non-printable whitespace chars

### DIFF
--- a/src/AbstractFilesystem.php
+++ b/src/AbstractFilesystem.php
@@ -3,6 +3,7 @@
 namespace Azura\Files;
 
 use Azura\Files\Adapter\ExtendedAdapterInterface;
+use Azura\Files\Normalizer\WhitespacePathNormalizer;
 use League\Flysystem\Filesystem;
 use League\Flysystem\PathNormalizer;
 use League\Flysystem\StorageAttributes;
@@ -18,6 +19,8 @@ abstract class AbstractFilesystem extends Filesystem implements ExtendedFilesyst
         PathNormalizer $pathNormalizer = null
     ) {
         $this->adapter = $adapter;
+
+        $pathNormalizer = $pathNormalizer ?: new WhitespacePathNormalizer();
 
         parent::__construct($adapter, $config, $pathNormalizer);
     }

--- a/src/Normalizer/WhitespacePathNormalizer.php
+++ b/src/Normalizer/WhitespacePathNormalizer.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Azura\Files\Normalizer;
+
+use League\Flysystem\PathNormalizer;
+use League\Flysystem\PathTraversalDetected;
+
+class WhitespacePathNormalizer implements PathNormalizer
+{
+    public function normalizePath(string $path): string
+    {
+        $path = str_replace('\\', '/', $path);
+        $path = $this->removeFunkyWhiteSpace($path);
+
+        return $this->normalizeRelativePath($path);
+    }
+
+    private function removeFunkyWhiteSpace(string $path): string
+    {
+        // Remove unprintable characters and invalid unicode characters.
+        // We do this check in a loop, since removing invalid unicode characters
+        // can lead to new characters being created.
+        //
+        // Customized regex for zero-width chars
+        // @see https://github.com/thephpleague/flysystem/issues/1157
+        while (preg_match('#\p{C}-[\x{200C}-\x{200D}]+|^\./#u', $path)) {
+            $path = (string) preg_replace('#\p{C}-[\x{200C}-\x{200D}]+|^\./#u', '', $path);
+        }
+
+        return $path;
+    }
+
+    private function normalizeRelativePath(string $path): string
+    {
+        $parts = [];
+
+        foreach (explode('/', $path) as $part) {
+            switch ($part) {
+                case '':
+                case '.':
+                    break;
+
+                case '..':
+                    if (empty($parts)) {
+                        throw PathTraversalDetected::forPath($path);
+                    }
+                    array_pop($parts);
+                    break;
+
+                default:
+                    $parts[] = $part;
+                    break;
+            }
+        }
+
+        return implode('/', $parts);
+    }
+}


### PR DESCRIPTION
We had some issues in the past with media files uploaded via SFTP that had file names containing non-printable chars that Flysystem wasn't able to handle correctly. This lead to the media processing failing for those users.

I have found an [issue on the Flysystem repo](https://github.com/thephpleague/flysystem/issues/1157) where this was reported around a year ago but the issue received no response and was closed due to inactivity after some time.

The gist of the issue is that with the default `WhitespacePathNormalizer` in Flysystem `zero-width` chars that are actually used in Old Hebrew and Persian are removed from paths due to the regex used.

I have created a `WhitespacePathNormalizer` that uses the proposed regex from the Flysystem issue I linked.

When I tested this with the file I received some time ago from a friend that had this issue I could verify that it could successfully process the media file with this changed regex.