### PR TITLE
Add an SFTP adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,8 @@
         "spatie/flysystem-dropbox": ">2.0.5"
     },
     "suggest": {
-        "spatie/flysystem-dropbox": "Dropbox adapter for Flysystem V2.",
-        "league/flysystem-aws-s3-v3": "AWS S3 API version 3 adapter for Flysystem V2.",
+        "spatie/flysystem-dropbox": "Dropbox adapter for Flysystem V3.",
+        "league/flysystem-aws-s3-v3": "AWS S3 API version 3 adapter for Flysystem V3.",
         "league/flysystem-sftp-v3": "SFTP adapter for Flysystem V3"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     },
     "require-dev": {
         "league/flysystem-aws-s3-v3": "^3.0",
+        "league/flysystem-sftp-v3": "^3.0",
         "php-parallel-lint/php-console-highlighter": "^0.5.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpstan/phpstan": "^1.0",
@@ -42,7 +43,8 @@
     },
     "suggest": {
         "spatie/flysystem-dropbox": "Dropbox adapter for Flysystem V2.",
-        "league/flysystem-aws-s3-v3": "AWS S3 API version 3 adapter for Flysystem V2."
+        "league/flysystem-aws-s3-v3": "AWS S3 API version 3 adapter for Flysystem V2.",
+        "league/flysystem-sftp-v3": "SFTP adapter for Flysystem V3"
     },
     "config": {
         "preferred-install": "dist",

--- a/src/Adapter/Sftp/SftpAdapter.php
+++ b/src/Adapter/Sftp/SftpAdapter.php
@@ -24,6 +24,8 @@ class SftpAdapter extends \League\Flysystem\PhpseclibV3\SftpAdapter implements E
 
     protected PathPrefixer $prefixer;
 
+    protected MimeTypeDetector $mimeTypeDetector;
+
     public function __construct(
         ConnectionProvider $connectionProvider,
         string $root,

--- a/src/Adapter/Sftp/SftpAdapter.php
+++ b/src/Adapter/Sftp/SftpAdapter.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Azura\Files\Adapter\Sftp;
+
+use Azura\Files\Adapter\ExtendedAdapterInterface;
+use Azura\Files\Attributes\DirectoryAttributes;
+use Azura\Files\Attributes\FileAttributes;
+use League\Flysystem\PathPrefixer;
+use League\Flysystem\PhpseclibV3\ConnectionProvider;
+use League\Flysystem\StorageAttributes;
+use League\Flysystem\UnableToRetrieveMetadata;
+use League\Flysystem\UnixVisibility\VisibilityConverter;
+use League\MimeTypeDetection\MimeTypeDetector;
+
+class SftpAdapter extends \League\Flysystem\PhpseclibV3\SftpAdapter implements ExtendedAdapterInterface
+{
+    protected const NET_SFTP_TYPE_DIRECTORY = 2;
+
+    protected ConnectionProvider $connectionProvider;
+
+    protected VisibilityConverter $visibilityConverter;
+
+    protected PathPrefixer $prefixer;
+
+    public function __construct(
+        ConnectionProvider $connectionProvider,
+        string $root,
+        VisibilityConverter $visibilityConverter = null,
+        MimeTypeDetector $mimeTypeDetector = null
+    ) {
+        $this->connectionProvider = $connectionProvider;
+        $this->visibilityConverter = $visibilityConverter;
+        $this->prefixer = new PathPrefixer($root);
+
+        parent::__construct($connectionProvider, $root, $visibilityConverter, $mimeTypeDetector);
+    }
+
+    /** @inheritDoc */
+    public function getMetadata(string $path): StorageAttributes
+    {
+        $location = $this->prefixer->prefixPath($path);
+        $connection = $this->connectionProvider->provideConnection();
+        $stat = $connection->stat($location);
+
+        if (!is_array($stat)) {
+            throw UnableToRetrieveMetadata::create($path, 'metadata');
+        }
+
+        $attributes = $this->convertListingToAttributes($path, $stat);
+
+        if (!$attributes instanceof FileAttributes) {
+            throw UnableToRetrieveMetadata::create($path, 'metadata', 'path is not a file');
+        }
+
+        return $attributes;
+    }
+
+    protected function convertListingToAttributes(string $path, array $attributes): StorageAttributes
+    {
+        $permissions = $attributes['mode'] & 0777;
+        $lastModified = $attributes['mtime'] ?? null;
+
+        if ($attributes['type'] === self::NET_SFTP_TYPE_DIRECTORY) {
+            return new DirectoryAttributes(
+                ltrim($path, '/'),
+                $this->visibilityConverter->inverseForDirectory($permissions),
+                $lastModified
+            );
+        }
+
+        return new FileAttributes(
+            $path,
+            $attributes['size'],
+            $this->visibilityConverter->inverseForFile($permissions),
+            $lastModified
+        );
+    }
+}

--- a/src/Adapter/Sftp/SftpAdapter.php
+++ b/src/Adapter/Sftp/SftpAdapter.php
@@ -25,8 +25,8 @@ class SftpAdapter extends \League\Flysystem\PhpseclibV3\SftpAdapter implements E
     public function __construct(
         ConnectionProvider $connectionProvider,
         string $root,
-        VisibilityConverter $visibilityConverter = null,
-        MimeTypeDetector $mimeTypeDetector = null
+        ?VisibilityConverter $visibilityConverter = null,
+        ?MimeTypeDetector $mimeTypeDetector = null
     ) {
         $this->connectionProvider = $connectionProvider;
         $this->visibilityConverter = $visibilityConverter;

--- a/src/Adapter/Sftp/SftpAdapter.php
+++ b/src/Adapter/Sftp/SftpAdapter.php
@@ -9,7 +9,9 @@ use League\Flysystem\PathPrefixer;
 use League\Flysystem\PhpseclibV3\ConnectionProvider;
 use League\Flysystem\StorageAttributes;
 use League\Flysystem\UnableToRetrieveMetadata;
+use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\UnixVisibility\VisibilityConverter;
+use League\MimeTypeDetection\FinfoMimeTypeDetector;
 use League\MimeTypeDetection\MimeTypeDetector;
 
 class SftpAdapter extends \League\Flysystem\PhpseclibV3\SftpAdapter implements ExtendedAdapterInterface
@@ -25,11 +27,11 @@ class SftpAdapter extends \League\Flysystem\PhpseclibV3\SftpAdapter implements E
     public function __construct(
         ConnectionProvider $connectionProvider,
         string $root,
-        ?VisibilityConverter $visibilityConverter = null,
-        ?MimeTypeDetector $mimeTypeDetector = null
+        VisibilityConverter $visibilityConverter = null,
+        MimeTypeDetector $mimeTypeDetector = null
     ) {
-        $this->connectionProvider = $connectionProvider;
-        $this->visibilityConverter = $visibilityConverter;
+        $this->visibilityConverter = $visibilityConverter ?: new PortableVisibilityConverter();
+        $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
         $this->prefixer = new PathPrefixer($root);
 
         parent::__construct($connectionProvider, $root, $visibilityConverter, $mimeTypeDetector);


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR adds an SFTP adapter to make it possible to add SFTP storage locations in AzuraCast.

With this one can for example use cheap storage hosting solutions like a [Hetzner Storage Box](https://www.hetzner.com/storage/storage-box?country=us) for their automated backups or even as their media storage.

What this also enables is sharing media files across multiple AzuraCast installations via the built-in SFTP server for AzuraCast stations.

I have also already prepared the respective changes needed for AzuraCast but before I can submit a PR for that I need this PR here to be merged since I don't want to submit a PR with a dev-branch of my own fork in AzuraCast.