### PR TITLE
Fix access before initialization error

### DIFF
--- a/src/Adapter/Sftp/SftpAdapter.php
+++ b/src/Adapter/Sftp/SftpAdapter.php
@@ -32,6 +32,7 @@ class SftpAdapter extends \League\Flysystem\PhpseclibV3\SftpAdapter implements E
         VisibilityConverter $visibilityConverter = null,
         MimeTypeDetector $mimeTypeDetector = null
     ) {
+        $this->connectionProvider = $connectionProvider;
         $this->visibilityConverter = $visibilityConverter ?: new PortableVisibilityConverter();
         $this->mimeTypeDetector = $mimeTypeDetector ?: new FinfoMimeTypeDetector();
         $this->prefixer = new PathPrefixer($root);


### PR DESCRIPTION
**Fixes issue:**
x

**Proposed changes:**
This PR fixes an access before initialization error reported to us via Discord:
```
[2022-05-08T17:37:37.586505+00:00] AzuraCast.ERROR: Typed property Azura\Files\Adapter\Sftp\SftpAdapter::$connectionProvider must not be accessed before initialization {"file":"/var/azuracast/www/vendor/azuracast/flysystem-v2-extensions/src/Adapter/Sftp/SftpAdapter.php","line":46,"code":0} []
```

This error happens on accessing metadata from an SftpAdapater due to me forgetting to put the supplied ConnectionProvider into the `protected` property.